### PR TITLE
[VIT-617] Testkit delete order endpoint

### DIFF
--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -11,6 +11,11 @@ def client_user_id() -> str:
 
 
 @pytest.fixture(scope="session")
+def client_order_id() -> str:
+    return "test_client_order_id"
+
+
+@pytest.fixture(scope="session")
 def test_client() -> Client:
     return Client(
         client_id=os.environ["TEST_CLIENT_ID"],

--- a/tests/api/e2e/test_testkits.py
+++ b/tests/api/e2e/test_testkits.py
@@ -21,16 +21,13 @@ def test_testkits_orders(
     assert order["id"] == client_order_id
     assert order["user_id"] == user_id
 
-    try:
-        response = test_client.Testkits.cancel_order(order_id=client_order_id)
-        assert response == {"success": True}
+    response = test_client.Testkits.cancel_order(order_id=client_order_id)
+    assert response == {"success": True}
 
-        orders = test_client.Testkits.get_orders(start_date, end_date, status=["ordered"])
-        assert len(orders["orders"]) == 0
+    orders = test_client.Testkits.get_orders(start_date, end_date, status=["ordered"])
+    assert len(orders["orders"]) == 0
 
-        orders = test_client.Testkits.get_orders(
-            start_date, end_date, status=["ordered", "cancelled"]
-        )
-        assert len(orders["orders"]) == 1
-    except Exception as e:
-        pass
+    orders = test_client.Testkits.get_orders(
+        start_date, end_date, status=["ordered", "cancelled"]
+    )
+    assert len(orders["orders"]) == 1

--- a/tests/api/e2e/test_testkits.py
+++ b/tests/api/e2e/test_testkits.py
@@ -1,0 +1,36 @@
+from vital import Client
+
+
+def test_testkits_orders(
+    test_client: Client,
+    user_id: str,
+    client_order_id: str,
+    start_date: str,
+    end_date: str,
+) -> None:
+    if client_order_id == "test_client_order_id":
+        # Can only test this if the client_order_id is set to a real value
+        return
+
+    orders = test_client.Testkits.get_orders(start_date, end_date)
+    assert len(orders["orders"]) > 0
+    assert orders["orders"][0]["id"] == client_order_id
+    assert orders["orders"][0]["user_id"] == user_id
+
+    order = test_client.Testkits.get_order(order_id=client_order_id)
+    assert order["id"] == client_order_id
+    assert order["user_id"] == user_id
+
+    try:
+        response = test_client.Testkits.cancel_order(order_id=client_order_id)
+        assert response == {"success": True}
+
+        orders = test_client.Testkits.get_orders(start_date, end_date, status=["ordered"])
+        assert len(orders["orders"]) == 0
+
+        orders = test_client.Testkits.get_orders(
+            start_date, end_date, status=["ordered", "cancelled"]
+        )
+        assert len(orders["orders"]) == 1
+    except Exception as e:
+        pass

--- a/tests/api/e2e/test_testkits.py
+++ b/tests/api/e2e/test_testkits.py
@@ -22,7 +22,9 @@ def test_testkits_orders(
     assert order["user_id"] == user_id
 
     response = test_client.Testkits.cancel_order(order_id=client_order_id)
-    assert response == {"success": True}
+    assert response["status"] == "success"
+    assert response["order"]["id"] == client_order_id
+    assert response["order"]["user_id"] == user_id
 
     orders = test_client.Testkits.get_orders(start_date, end_date, status=["ordered"])
     assert len(orders["orders"]) == 0

--- a/vital/api/testkits.py
+++ b/vital/api/testkits.py
@@ -60,9 +60,9 @@ class Testkits(API):
             {"start_date": start_date, "end_date": end_date, "status": status},
         )
 
-    def cancel_order(self, order_id: str) -> Mapping[str, bool]:
+    def cancel_order(self, order_id: str) -> Mapping[str, str]:
         """
         Cancel order.
         :param str user_id: The order_id.
         """
-        return self.client.delete(f"/testkit/orders/{order_id}")
+        return self.client.post(f"/testkit/orders/{order_id}/cancel")

--- a/vital/api/testkits.py
+++ b/vital/api/testkits.py
@@ -50,7 +50,7 @@ class Testkits(API):
         return self.client.get(f"/testkit/orders/{order_id}")
 
     def get_orders(
-        self, start_date: str, end_date: str, status: Optional[List[str]]
+        self, start_date: str, end_date: str, status: Optional[List[str]] = None
     ) -> Mapping[str, str]:
         """
         Get all orders.

--- a/vital/api/testkits.py
+++ b/vital/api/testkits.py
@@ -1,4 +1,4 @@
-from typing import Dict, Mapping
+from typing import Dict, List, Mapping, Optional
 
 from vital.api.api import API
 
@@ -49,10 +49,20 @@ class Testkits(API):
         """
         return self.client.get(f"/testkit/orders/{order_id}")
 
-    def get_orders(self, start_date: str, end_date: str) -> Mapping[str, str]:
+    def get_orders(
+        self, start_date: str, end_date: str, status: Optional[List[str]]
+    ) -> Mapping[str, str]:
         """
         Get all orders.
         """
         return self.client.get(
-            "/testkit/orders", {"start_date": start_date, "end_date": end_date}
+            "/testkit/orders",
+            {"start_date": start_date, "end_date": end_date, "status": status},
         )
+
+    def cancel_order(self, order_id: str) -> Mapping[str, bool]:
+        """
+        Cancel order.
+        :param str user_id: The order_id.
+        """
+        return self.client.delete(f"/testkit/orders/{order_id}")

--- a/vital/client.py
+++ b/vital/client.py
@@ -26,6 +26,7 @@ base_urls = {
     "prod": "https://api.tryvital.io",
     "production": "https://api.tryvital.io",
     "dev": "https://api.dev.tryvital.io",
+    "development": "https://api.dev.tryvital.io",
     "sandbox": "https://api.sandbox.tryvital.io",
 }
 


### PR DESCRIPTION
Add status parameter to Testkit.get_orders() and add Testkit.cancel_order()

The try/catch is there because we need to merge #305 in vital-background-pull first.